### PR TITLE
Lower log severity of memcache failures

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/MemcacheServiceRetryProxy.java
+++ b/src/main/java/com/googlecode/objectify/cache/MemcacheServiceRetryProxy.java
@@ -54,7 +54,7 @@ public class MemcacheServiceRetryProxy implements InvocationHandler
 				return meth.invoke(this.raw, args);
 			} catch (InvocationTargetException ex) {
 				if (i == (this.tries - 1))
-					log.error("Memcache operation failed, giving up", ex);
+					log.warn("Memcache operation failed, giving up", ex);
 				else
 					log.warn("Error performing memcache operation, retrying: " + meth, ex);
 			}


### PR DESCRIPTION
We will be releasing this branch as its own release, as well as merging it into main. Once we are able to use the changes in main w.r.t. our datastore emulator, we can use that.

Relates to: ARC-3625