### PR TITLE
ARC-6669 reduce error level of log - we expect this to happen are redis will have timeouts, etc

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/MemcacheServiceRetryProxy.java
+++ b/src/main/java/com/googlecode/objectify/cache/MemcacheServiceRetryProxy.java
@@ -54,9 +54,9 @@ public class MemcacheServiceRetryProxy implements InvocationHandler
 				return meth.invoke(this.raw, args);
 			} catch (InvocationTargetException ex) {
 				if (i == (this.tries - 1))
-					log.error("Memcache operation failed, giving up", ex);
+					log.warn("Memcache operation failed, giving up on the cache", ex);
 				else
-					log.warn("Error performing memcache operation, retrying: " + meth, ex);
+                    log.warn("Error performing memcache operation, retrying: {}", meth, ex);
 			}
 		}
 		


### PR DESCRIPTION
ARC-6669 reduce error level of log - we expect this to happen are redis will have timeouts, etc

This was actually previously done in ARC-3625 but only on a forked branch