### PR TITLE
ARC-7982 bump datastore lib to latest version (including implementing new interface methods)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,5 @@
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-datastore</artifactId>
-			<version>2.25.1</version>
+			<version>2.28.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/googlecode/objectify/impl/StuffingQueryResults.java
+++ b/src/main/java/com/googlecode/objectify/impl/StuffingQueryResults.java
@@ -4,8 +4,11 @@ import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.models.ExplainMetrics;
 import com.google.datastore.v1.QueryResultBatch.MoreResultsType;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
 
 /**
  * Takes a normal Entity-based QueryResults and converts it to a Key-based QueryResults while
@@ -47,5 +50,10 @@ class StuffingQueryResults implements QueryResults<Key> {
 	@Override
 	public MoreResultsType getMoreResults() {
 		return base.getMoreResults();
+	}
+
+	@Override
+	public Optional<ExplainMetrics> getExplainMetrics() {
+		return base.getExplainMetrics();
 	}
 }

--- a/src/main/java/com/googlecode/objectify/util/cmd/TransactionWrapper.java
+++ b/src/main/java/com/googlecode/objectify/util/cmd/TransactionWrapper.java
@@ -1,5 +1,7 @@
 package com.googlecode.objectify.util.cmd;
 
+import com.google.cloud.datastore.AggregationQuery;
+import com.google.cloud.datastore.AggregationResults;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.FullEntity;
@@ -7,6 +9,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.Transaction;
+import com.google.cloud.datastore.models.ExplainOptions;
 import com.google.protobuf.ByteString;
 import lombok.Data;
 
@@ -39,6 +42,21 @@ public class TransactionWrapper implements Transaction {
 	@Override
 	public <T> QueryResults<T> run(final Query<T> query) {
 		return raw.run(query);
+	}
+
+	@Override
+	public AggregationResults runAggregation(AggregationQuery aggregationQuery) {
+		return raw.runAggregation(aggregationQuery);
+	}
+
+	@Override
+	public AggregationResults runAggregation(AggregationQuery aggregationQuery, ExplainOptions explainOptions) {
+		return raw.runAggregation(aggregationQuery, explainOptions);
+	}
+
+	@Override
+	public <T> QueryResults<T> run(Query<T> query, ExplainOptions explainOptions) {
+		return raw.run(query, explainOptions);
 	}
 
 	@Override


### PR DESCRIPTION
Bump datastore to latest version - should hopefully fix the protobuf compatibility errors we've been getting.

Also add dependabot - these ones will be slightly more involved as we don't have CI/CD setup but we should be making sure we address CVEs 