### PR TITLE
HOT-173: release objectify 6.2.0 (Valkey support)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>nct.forks.objectify</groupId>
 	<artifactId>objectify</artifactId>
-	<version>6.1.6-SNAPSHOT</version>
+	<version>6.2.0</version>
 
 	<name>Objectify App Engine</name>
 	<description>The simplest convenient interface to the Google App Engine datastore</description>
@@ -23,7 +23,7 @@
 	<scm>
 		<url>scm:git:https://github.com/UpsideRealty/objectify</url>
 		<developerConnection>scm:git:git@github.com:UpsideRealty/objectify.git</developerConnection>
-		<tag>objectify-6.1.3</tag>
+		<tag>objectify-6.2.0</tag>
 	</scm>
 	<licenses>
 		<license>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>nct.forks.objectify</groupId>
 	<artifactId>objectify</artifactId>
-	<version>6.2.0</version>
+	<version>6.2.1-SNAPSHOT</version>
 
 	<name>Objectify App Engine</name>
 	<description>The simplest convenient interface to the Google App Engine datastore</description>
@@ -23,7 +23,7 @@
 	<scm>
 		<url>scm:git:https://github.com/UpsideRealty/objectify</url>
 		<developerConnection>scm:git:git@github.com:UpsideRealty/objectify.git</developerConnection>
-		<tag>objectify-6.2.0</tag>
+		<tag>objectify-6.1.3</tag>
 	</scm>
 	<licenses>
 		<license>


### PR DESCRIPTION
## HOT-173 — cut `objectify-6.2.0`

Maven-release-plugin commits prepared locally with `-DpushChanges=false` because the org `pull_request` ruleset on `main` blocks direct push. Standard `mvn release:prepare` two-commit sequence:

1. `[maven-release-plugin] prepare release objectify-6.2.0` — `pom.xml`: `6.1.6-SNAPSHOT` → `6.2.0`
2. `[maven-release-plugin] prepare for next development iteration` — `pom.xml`: `6.2.0` → `6.2.1-SNAPSHOT`

Releases the Valkey 9.0 `MemcacheService` from #12 so the monolith can bump `nctObjectify` to `6.2.0` and switch the Objectify entity cache off Redis.

### Pre-flight
- `mvn -B test` against the local `memcached-docker` compose stack: **366 tests, 0 failures, 0 errors, 5 skipped** on Zulu 17.0.18.
- `mvn -B release:prepare` build phase succeeded (compile + tests + javadoc jar).
- Tag `objectify-6.2.0` exists locally and points at the `prepare release` commit (matches the `objectify-6.1.5` pattern).

### Merge strategy — must be **Rebase and merge**

The `required_linear_history` rule rules out a merge commit, and squash would collapse the two release-plugin commits into one (breaking the `prepare for next development iteration` invariant that the maven release plugin relies on).

Rebase re-writes the commit SHAs on merge, so after this merges I'll re-tag `objectify-6.2.0` on the new SHA before running `mvn release:perform` to publish the artifact to `nct-maven-release`.

### Follow-up
- `mvn release:perform` from `main` post-merge → artifact lands at `australia-southeast1-maven.pkg.dev/upside-ci/nct-maven-release/com/googlecode/objectify/objectify/6.2.0/`.
- Monolith PR `kieran/HOT-173-bump-objectify-6.2.0` pins `nctObjectify = "6.2.0"` and triggers CI.
- HOT-173 PR #18976 (Memorystore for Valkey provisioning) lands in parallel; application cut-over PR will follow.

HOT-173: https://vmxproperty.atlassian.net/browse/HOT-173

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author